### PR TITLE
fix: do not require file extensions for ts,tsx imports

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -12,6 +12,17 @@ module.exports = {
           { argsIgnorePattern: '^_', args: 'after-used', ignoreRestSiblings: true },
         ],
         '@typescript-eslint/indent': 'off',
+        'import/extensions': [
+          'error',
+          'ignorePackages',
+          {
+            ts: 'never',
+            tsx: 'never',
+            js: 'never',
+            jsx: 'never',
+            mjs: 'never',
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
We get our import rules form `airbnb-config-base`, but that doesn't take ts/tsx into account, so we were requiring file extensions when importing typescript files. 

This PR fixes the `import/extensions` rule so it excludes `ts` and `tsx` extensions. 